### PR TITLE
Handle large audit event upload to Azure blob

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,37 @@ We recommend developers use Seq locally to help ensure the audit event developme
 
 ![Sample Seq Output](./assets/seq-events-view.png)
 
+## Using custom sink for large audit events
+
+With increasing size in audit events large audit events couldn't be processed by `Kmd.Logic.Audit.Client.SerilogAzureEventHubs.SerilogAzureEventHubsAuditClient` implementation. As a solution to this we came up with a custom sink which based on the size of audit event will push the event to blob for large messages and keep the blob url in event hub. The default bytes limit is 256 KB which is customizable.
+
+To use the custom sink you need to use the `Kmd.Logic.Audit.Client.SerilogLargeAuditEvents` implementation.
+
+You need to create the client configuration of `Kmd.Logic.Audit.Client.SerilogLargeAuditEvents` where the connection properties of event hub and blob storage can be provided. The event size limit can also be customized here.
+
+```csharp
+var clientConfig = new Kmd.Logic.Audit.Client.SerilogLargeAuditEvents.SerilogLargeAuditEventClientConfiguration
+    {
+        EventSource = {EventSource},
+        AuditEventTopic = {EventTopic},
+        EventHubConnectionString = {EventHubConnectionString},
+        EnrichFromLogContext = true,
+        StorageAccountName = {StorageAccountName},
+        StorageConnectionString = {StorageConnectionString},
+        StorageContainerName = {ContainerName},
+        EventSizeLimitinBytes = {EventSizeLimitinBytes}
+    };
+```
+
+After creating the client configuration create the `Kmd.Logic.Audit.Client.SerilogLargeAuditEvents` client.
+
+```csharp
+using (var audit = new Kmd.Logic.Audit.Client.SerilogLargeAuditEvents.SerilogLargeAuditEventClient(clientConfig))
+{
+    // write your audit events here
+}
+```
+
 ## Using KMD Logic Audit as the destination of audit events
 
 Contact us at discover@kmdlogic.io for more information.

--- a/src/Kmd.Logic.Audit.Client.SerilogLargeAuditEvents/AzureBlobOrEventHubCustomSink/AzureBlobOrEventHubSink.cs
+++ b/src/Kmd.Logic.Audit.Client.SerilogLargeAuditEvents/AzureBlobOrEventHubCustomSink/AzureBlobOrEventHubSink.cs
@@ -58,7 +58,7 @@ namespace Kmd.Logic.Audit.Client.SerilogLargeAuditEvents.AzureBlobOrEventHubCust
                 eventId = eventIdValue.ToString();
             }
 
-            return AzureBlobServiceProvider.UploadBlob(this.blobServiceClient, this.storageContainerName, eventId, content);
+            return AzureBlobUploadManager.UploadBlob(this.blobServiceClient, this.storageContainerName, eventId, content);
         }
     }
 }

--- a/src/Kmd.Logic.Audit.Client.SerilogLargeAuditEvents/AzureBlobOrEventHubCustomSink/AzureBlobServiceProvider.cs
+++ b/src/Kmd.Logic.Audit.Client.SerilogLargeAuditEvents/AzureBlobOrEventHubCustomSink/AzureBlobServiceProvider.cs
@@ -92,7 +92,6 @@ namespace Kmd.Logic.Audit.Client.SerilogLargeAuditEvents.AzureBlobOrEventHubCust
                         {
                             var blockId = Convert.ToBase64String(Encoding.UTF8.GetBytes(counter.ToString("d3", CultureInfo.InvariantCulture)));
                             blockBlobClient.StageBlock(blockId, new MemoryStream(data));
-                            Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "Block {0} uploaded successfully.", counter.ToString("d3", CultureInfo.InvariantCulture)));
                             blockIds.Add(blockId);
                             counter++;
                         }

--- a/src/Kmd.Logic.Audit.Client.SerilogLargeAuditEvents/SerilogLargeAuditEventClient.cs
+++ b/src/Kmd.Logic.Audit.Client.SerilogLargeAuditEvents/SerilogLargeAuditEventClient.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using Azure.Storage.Blobs;
+using Serilog;
 using Serilog.Core;
+using Serilog.Debugging;
 
 namespace Kmd.Logic.Audit.Client.SerilogLargeAuditEvents
 {
@@ -14,6 +16,7 @@ namespace Kmd.Logic.Audit.Client.SerilogLargeAuditEvents
         {
             this.customSinkLogger = config.CreateDefaultAzureBlobOrEventHubConfiguration().CreateLogger();
             this.disposeLogger = true;
+            SelfLog.Enable(msg => Console.WriteLine(msg));
             this.auditToCustomSink = new SerilogCustomSinkLoggerAudit(this.customSinkLogger);
         }
 
@@ -21,6 +24,7 @@ namespace Kmd.Logic.Audit.Client.SerilogLargeAuditEvents
         {
             this.customSinkLogger = config.CreateAzureBlobOrEventHubConfiguration(blobServiceClient).CreateLogger();
             this.disposeLogger = true;
+            SelfLog.Enable(msg => Console.WriteLine(msg));
             this.auditToCustomSink = new SerilogCustomSinkLoggerAudit(this.customSinkLogger);
         }
 
@@ -28,6 +32,7 @@ namespace Kmd.Logic.Audit.Client.SerilogLargeAuditEvents
         {
             this.customSinkLogger = logger;
             this.disposeLogger = disposeLogger;
+            SelfLog.Enable(msg => Console.WriteLine(msg));
             this.auditToCustomSink = new SerilogCustomSinkLoggerAudit(this.customSinkLogger);
         }
 


### PR DESCRIPTION
- When audit event size is pretty large, audit client with custom sink having single blob upload couldn't handle. Hence the blob upload has to be done in chunks.

- Each chunk will be of size 4 MB. If an audit event is more than 4 MB then it will be uploaded in chunks otherwise it will be uploaded in one upload.